### PR TITLE
Add more customization options to script.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,28 @@
+# Build Scripts
+
+## build.sh
+
+```
+This script builds a bootable ubuntu ISO image
+
+Supported commands : setup_host debootstrap run_chroot build_iso
+
+Syntax: ./build.sh [start_cmd] [-] [end_cmd]
+	run from start_cmd to end_end
+	if start_cmd is omitted, start from first command
+	if end_cmd is omitted, end with last command
+	enter single cmd to run the specific command
+	enter '-' as only argument to run all commands
+```
+
+## How to Customize
+
+1. Copy the `default_config.sh` file to `config.sh` in the scripts directory.
+2. Make any necessary edits there, the script will pick up `config.sh` over `default_config.sh`.
+
+## How to Update
+
+The configuration script is versioned with the variable CONFIG_FILE_VERSION.  Any time that the configuration
+format is changed in `default_config.sh`, this value is bumped.  Once this happens `config.sh` must be updated manually
+from the default file to ensure the new/changed variables are as desired.  Once the merge is complete the `config.sh` file's
+CONFIG_FILE_VERSION should match the default and the build will run.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -88,7 +88,7 @@ function load_config() {
 # Verify that necessary configuration values are set and they are valid
 function check_config() {
     local expected_config_version
-    expected_config_version="0.1"
+    expected_config_version="0.2"
 
     if [[ "$CONFIG_FILE_VERSION" != "$expected_config_version" ]]; then
         >&2 echo "Invalid or old config version $CONFIG_FILE_VERSION, expected $expected_config_version. Please update your configuration file from the default."
@@ -105,7 +105,7 @@ function setup_host() {
 
 function debootstrap() {
     echo "=====> running debootstrap ... will take a couple of minutes ..."
-    sudo debootstrap  --arch=amd64 --variant=minbase focal chroot  http://us.archive.ubuntu.com/ubuntu/
+    sudo debootstrap  --arch=amd64 --variant=minbase $TARGET_UBUNTU_VERSION chroot http://us.archive.ubuntu.com/ubuntu/
 }
 
 function run_chroot() {
@@ -257,7 +257,7 @@ EOF
         -as mkisofs \
         -iso-level 3 \
         -full-iso9660-filenames \
-        -volid "Ubuntu from scratch" \
+        -volid "$TARGET_NAME" \
         -eltorito-boot boot/grub/bios.img \
         -no-emul-boot \
         -boot-load-size 4 \
@@ -269,7 +269,7 @@ EOF
         -e EFI/efiboot.img \
         -no-emul-boot \
         -append_partition 2 0xef isolinux/efiboot.img \
-        -output "../ubuntu-from-scratch.iso" \
+        -output "$SCRIPT_DIR/$TARGET_NAME.iso" \
         -m "isolinux/efiboot.img" \
         -m "isolinux/bios.img" \
         -graft-points \

--- a/scripts/chroot_build.sh
+++ b/scripts/chroot_build.sh
@@ -56,17 +56,17 @@ function setup_host() {
     echo "=====> running setup_host ..."
 
    cat <<EOF > /etc/apt/sources.list
-deb http://us.archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
+deb http://us.archive.ubuntu.com/ubuntu/ $TARGET_UBUNTU_VERSION main restricted universe multiverse
+deb-src http://us.archive.ubuntu.com/ubuntu/ $TARGET_UBUNTU_VERSION main restricted universe multiverse
 
-deb http://us.archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+deb http://us.archive.ubuntu.com/ubuntu/ $TARGET_UBUNTU_VERSION-security main restricted universe multiverse
+deb-src http://us.archive.ubuntu.com/ubuntu/ $TARGET_UBUNTU_VERSION-security main restricted universe multiverse
 
-deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+deb http://us.archive.ubuntu.com/ubuntu/ $TARGET_UBUNTU_VERSION-updates main restricted universe multiverse
+deb-src http://us.archive.ubuntu.com/ubuntu/ $TARGET_UBUNTU_VERSION-updates main restricted universe multiverse
 EOF
 
-    echo "ubuntu-fs-live" > /etc/hostname
+    echo "$TARGET_NAME" > /etc/hostname
 
     # we need to install systemd first, to configure machine id
     apt-get update
@@ -98,7 +98,7 @@ function install_pkg() {
     echo "=====> running install_pkg ... will take a long time ..."
     apt-get -y upgrade
 
-    # install live linux packages
+    # install live packages
     apt-get install -y \
     sudo \
     ubuntu-standard \
@@ -112,8 +112,10 @@ function install_pkg() {
     net-tools \
     wireless-tools \
     wpagui \
-    locales \
-    linux-generic
+    locales
+    
+    # install kernel
+    apt-get install -y --install-recommends $TARGET_KERNEL_PACKAGE
 
     # graphic installer - ubiquity
     apt-get install -y \

--- a/scripts/default_config.sh
+++ b/scripts/default_config.sh
@@ -5,9 +5,17 @@
 # Usage: Copy this file to config.sh and make changes there.  Keep this file (default_config.sh) as-is
 #   so that subsequent changes can be easily merged from upstream.  Keep all customiations in config.sh
 
-# Used to version the configuration.  If breaking changes occur, manual
-# updates to this file from the default may be necessary.
-export CONFIG_FILE_VERSION="0.1"
+# The version of Ubuntu to generate.  Successfully tested: focal, groovy
+# See https://wiki.ubuntu.com/DevelopmentCodeNames for details
+export TARGET_UBUNTU_VERSION="focal"
+
+# The packaged version of the Linux kernel to install on target image.
+# See https://wiki.ubuntu.com/Kernel/LTSEnablementStack for details
+export TARGET_KERNEL_PACKAGE="linux-generic"
+
+# The file (no extension) of the ISO containing the generated disk image,
+# the volume id, and the hostname of the live environment are set from this name.
+export TARGET_NAME="ubuntu-from-scratch"
 
 # The text label shown in GRUB for booting into the live environment
 export GRUB_LIVEBOOT_LABEL="Try Ubuntu FS without installing"
@@ -44,3 +52,7 @@ function customize_image() {
     aisleriot \
     hitori
 }
+
+# Used to version the configuration.  If breaking changes occur, manual
+# updates to this file from the default may be necessary.
+export CONFIG_FILE_VERSION="0.2"


### PR DESCRIPTION
Changes:

* Add ability to specify Ubuntu version (focal, groovy tested)
* Add ability to specify Linux package to install (linux-generic, linux-generic-hwe-20.04 tested)
* Add ability to specify system "name" which writes to ISO volume id, hostname, and iso filename.
* Version bump config file for breaking change
* Add readme in scripts directory for instructions on how to use.

Tested HWE and Groovy in virtualbox

![VirtualBox_ubu3_21_04_2021_20_59_07](https://user-images.githubusercontent.com/49683/115658056-e1d8de80-a2ec-11eb-8952-f066c76302a2.png)
