### PR TITLE
Customize package removal

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -88,7 +88,7 @@ function load_config() {
 # Verify that necessary configuration values are set and they are valid
 function check_config() {
     local expected_config_version
-    expected_config_version="0.2"
+    expected_config_version="0.3"
 
     if [[ "$CONFIG_FILE_VERSION" != "$expected_config_version" ]]; then
         >&2 echo "Invalid or old config version $CONFIG_FILE_VERSION, expected $expected_config_version. Please update your configuration file from the default."
@@ -192,11 +192,9 @@ EOF
     # generate manifest
     sudo chroot chroot dpkg-query -W --showformat='${Package} ${Version}\n' | sudo tee image/casper/filesystem.manifest
     sudo cp -v image/casper/filesystem.manifest image/casper/filesystem.manifest-desktop
-    sudo sed -i '/ubiquity/d' image/casper/filesystem.manifest-desktop
-    sudo sed -i '/casper/d' image/casper/filesystem.manifest-desktop
-    sudo sed -i '/discover/d' image/casper/filesystem.manifest-desktop
-    sudo sed -i '/laptop-detect/d' image/casper/filesystem.manifest-desktop
-    sudo sed -i '/os-prober/d' image/casper/filesystem.manifest-desktop
+    for pkg in $TARGET_PACKAGE_REMOVE; do
+        sudo sed -i "/$pkg/d" image/casper/filesystem.manifest-desktop
+    done
 
     # compress rootfs
     sudo mksquashfs chroot image/casper/filesystem.squashfs \

--- a/scripts/default_config.sh
+++ b/scripts/default_config.sh
@@ -23,6 +23,15 @@ export GRUB_LIVEBOOT_LABEL="Try Ubuntu FS without installing"
 # The text label shown in GRUB for starting installation
 export GRUB_INSTALL_LABEL="Install Ubuntu FS"
 
+# Packages to be removed from the target system after installation completes succesfully
+export TARGET_PACKAGE_REMOVE="
+    ubiquity \
+    casper \
+    discover \
+    laptop-detect \
+    os-prober \
+"
+
 # Package customisation function.  Update this function to customize packages
 # present on the installed system.
 function customize_image() {
@@ -55,4 +64,4 @@ function customize_image() {
 
 # Used to version the configuration.  If breaking changes occur, manual
 # updates to this file from the default may be necessary.
-export CONFIG_FILE_VERSION="0.2"
+export CONFIG_FILE_VERSION="0.3"


### PR DESCRIPTION
## Summary

This PR extracts the list of packages to prune from `filesystem.manifest-desktop`.  This would allow users to remove packages required during the installation process but not desired on the target system.

## Testing Done

I generated an ISO and checked the files after the image was created to verify the expected file contents:

```bash
$ diff filesystem.manifest filesystem.manifest-desktop 
60d59
< casper 1.445.1
115,116d113
< discover 2.1.2-8
< discover-data 2.2013.01.11ubuntu1
453d449
< laptop-detect 0.16
584d579
< libdiscover2 2.1.2-8
1250d1244
< lupin-casper 0.57build1
1295d1288
< os-prober 1.74ubuntu2
1505,1509d1497
< ubiquity 20.04.15.11
< ubiquity-casper 1.445.1
< ubiquity-frontend-gtk 20.04.15.11
< ubiquity-slideshow-ubuntu 160
< ubiquity-ubuntu-artwork 20.04.15.11
```