### PR TITLE
Update action to compress and release ISO

### DIFF
--- a/.github/workflows/build-focal.yml
+++ b/.github/workflows/build-focal.yml
@@ -14,11 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Initiate Build
+      - name: Build
         run: |
           cd scripts
           ./build.sh -
-
-      - name: Debug
+      - name: Compress
         run: |
-          ls -hl scripts/
+          gzip scripts/ubuntu-from-scratch.iso
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: focal-latest
+          prerelease: true
+          files: |
+            scripts/ubuntu-from-scratch.iso.gz


### PR DESCRIPTION

This change publishes the ISO file with the release.  This allows people to verify that the image created by automation indeed works.

## Testing Done

I've tested this action in my personal repo.  

Release: https://github.com/kgilmer/live-custom-ubuntu-from-scratch/releases
Action: https://github.com/kgilmer/live-custom-ubuntu-from-scratch/actions/workflows/build-focal.yml