### PR TITLE
Add secureboot bootstrap package to allow target system to boot via UEFI

### DIFF
--- a/scripts/chroot_build.sh
+++ b/scripts/chroot_build.sh
@@ -112,10 +112,12 @@ function install_pkg() {
     net-tools \
     wireless-tools \
     wpagui \
-    locales
+    locales \
+    shim-signed
     
     # install kernel
-    apt-get install -y --install-recommends $TARGET_KERNEL_PACKAGE
+    apt-get install -y --install-recommends \
+    $TARGET_KERNEL_PACKAGE
 
     # graphic installer - ubiquity
     apt-get install -y \


### PR DESCRIPTION
Resolves https://github.com/mvallim/live-custom-ubuntu-from-scratch/issues/30

## Description of Change

This change adds the package `shim-signed` to the installation target.  This enables systems using UEFI to boot.  Without this change installation of the ISO results in an unbootable system.

## Testing Done
1. Verified that existing code does not boot on UEFI configured computer
2. Make change, generate ISO
3. Verified that new ISO results in a booting system on UEFI configured computer