### PR TITLE
install dosfstools (mkfs.vfat), unzip

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -99,7 +99,7 @@ function check_config() {
 function setup_host() {
     echo "=====> running setup_host ..."
     sudo apt update
-    sudo apt install -y binutils debootstrap squashfs-tools xorriso grub-pc-bin grub-efi-amd64-bin mtools
+    sudo apt install -y binutils debootstrap squashfs-tools xorriso grub-pc-bin grub-efi-amd64-bin mtools dosfstools unzip
     sudo mkdir -p chroot
 }
 


### PR DESCRIPTION
- The `build.sh` script uses `mkfs.vfat` and `unzip`, but doesn't install them. And those aren't present by default when building in a `ubuntu:20.04` container, so the build takes a long time and then fails if they aren't present.
- This adds those dependencies.