### PR TITLE
scripts: switch to Ubuntu Jammy Jellyfish (22.04) by default

### DIFF
--- a/.github/workflows/build-jammy.yml
+++ b/.github/workflows/build-jammy.yml
@@ -18,7 +18,6 @@ jobs:
         run: |
           cd scripts
           sed -i -E 's/TARGET_UBUNTU_VERSION=(.*)/TARGET_UBUNTU_VERSION="jammy"/g' default_config.sh
-          sed -i -E '/lupin-casper/d' chroot_build.sh
           ./build.sh -
           cd ..
       - name: Archive artifacts

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,3 +1,4 @@
 Marcos Vallim <tischer@gmail.com>
 Ken Gilmer <kgilmer@gmail.com>
 monkey-jsun <>
+Andreas Blaesius <andi@unlegacy-android.org>

--- a/scripts/chroot_build.sh
+++ b/scripts/chroot_build.sh
@@ -103,7 +103,6 @@ function install_pkg() {
     sudo \
     ubuntu-standard \
     casper \
-    lupin-casper \
     discover \
     laptop-detect \
     os-prober \
@@ -118,6 +117,15 @@ function install_pkg() {
     grub-pc-bin \
     grub2-common \
     locales
+    
+    case $TARGET_UBUNTU_VERSION in
+        "focal" | "bionic")
+            apt-get install -y lupin-casper
+            ;;
+        *)
+            echo "Package lupin-casper is not needed. Skipping."
+            ;;
+    esac
     
     # install kernel
     apt-get install -y --no-install-recommends $TARGET_KERNEL_PACKAGE

--- a/scripts/default_config.sh
+++ b/scripts/default_config.sh
@@ -5,9 +5,9 @@
 # Usage: Copy this file to config.sh and make changes there.  Keep this file (default_config.sh) as-is
 #   so that subsequent changes can be easily merged from upstream.  Keep all customiations in config.sh
 
-# The version of Ubuntu to generate.  Successfully tested: bionic, cosmic, disco, eoan, focal, groovy
+# The version of Ubuntu to generate.  Successfully tested: bionic, cosmic, disco, eoan, focal, groovy, jammy
 # See https://wiki.ubuntu.com/DevelopmentCodeNames for details
-export TARGET_UBUNTU_VERSION="focal"
+export TARGET_UBUNTU_VERSION="jammy"
 
 # The Ubuntu Mirror URL. It's better to change for faster download.
 # More mirrors see: https://launchpad.net/ubuntu/+archivemirrors


### PR DESCRIPTION
lupin-casper is not available on Ubuntu Jammy Jellyfish, only install on other Ubuntu versions.

Fixes https://github.com/mvallim/live-custom-ubuntu-from-scratch/issues/45