### PR TITLE
Use LZ compression when creating the SquashFS to significantly reduce the size of the compiled file. (2GB->1.6GB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,16 @@ After everything has been installed and preconfigured in the **chrooted** enviro
 2. Create squashfs
 
    ```shell
-   sudo mksquashfs chroot image/casper/filesystem.squashfs
+   sudo mksquashfs chroot image/casper/filesystem.squashfs \
+        -noappend -no-duplicates -no-recovery \
+        -wildcards \
+        -comp xz -b 1M -Xdict-size 100% \
+        -e "var/cache/apt/archives/*" \
+        -e "root/*" \
+        -e "root/.*" \
+        -e "tmp/*" \
+        -e "tmp/.*" \
+        -e "swapfile"
    ```
 
    > **Squashfs** is a highly compressed read-only filesystem for Linux. It uses zlib compression to compress both files, inodes and directories. Inodes in the system are very small and all blocks are packed to minimize data overhead. Block sizes greater than 4K are supported up to a maximum of 64K.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -200,6 +200,7 @@ EOF
     sudo mksquashfs chroot image/casper/filesystem.squashfs \
         -noappend -no-duplicates -no-recovery \
         -wildcards \
+        -comp xz -b 1M -Xdict-size 100% \
         -e "var/cache/apt/archives/*" \
         -e "root/*" \
         -e "root/.*" \


### PR DESCRIPTION
Use LZ compression when creating the SquashFS to significantly reduce the size of the compiled file (approximately 
 2GB -> 1.6GB)).

![image](https://github.com/user-attachments/assets/a31c6388-ba81-4378-a19b-5d8c52a712c0)

