### PR TITLE
add unzip to the list of install pkgs

### DIFF
--- a/scripts/chroot_build.sh
+++ b/scripts/chroot_build.sh
@@ -118,6 +118,7 @@ function install_pkg() {
         grub-efi-amd64-signed \
         shim-signed \
         mtools \
+        unzip \
         binutils
     
     case $TARGET_UBUNTU_VERSION in


### PR DESCRIPTION
This change adds `unzip` to the list of pkgs installed in the `chroot`.

Without this change, I get the following error when during the `run_chroot` phase:
```
...
=====> running build_image ...
/image /
--2025-04-03 00:20:00--  https://memtest.org/download/v7.00/mt86plus_7.00.binaries.zip
Resolving xxx (xxx)... x.x.x.x
Connecting to xxx (xxx)|x.x.x.x|:3128... connected.
Proxy request sent, awaiting response... 200 OK
Length: 270657 (264K) [application/zip]
Saving to: 'install/memtest86.zip'

     0K .......... .......... .......... .......... .......... 18%  302K 1s
    50K .......... .......... .......... .......... .......... 37%  605K 0s
   100K .......... .......... .......... .......... .......... 56% 31.9M 0s
   150K .......... .......... .......... .......... .......... 75%  626K 0s
   200K .......... .......... .......... .......... .......... 94% 23.6M 0s
   250K .......... ....                                       100% 58.0M=0.3s

2025-04-03 00:20:01 (796 KB/s) - 'install/memtest86.zip' saved [270657/270657]

/root/chroot_build.sh: line 183: unzip: command not found
```