### PR TITLE
bugfix: chroot_exit_teardown

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,6 +43,11 @@ function find_index() {
     help "Command not found : $1"
 }
 
+function chroot_enter_debug() {
+      sudo chroot chroot
+}
+export -f chroot_enter_debug
+
 function chroot_enter_setup() {
     sudo mount --bind /dev chroot/dev
     sudo mount --bind /run chroot/run
@@ -50,14 +55,16 @@ function chroot_enter_setup() {
     sudo chroot chroot mount none -t sysfs /sys
     sudo chroot chroot mount none -t devpts /dev/pts
 }
+export -f chroot_enter_setup
 
 function chroot_exit_teardown() {
-    sudo chroot chroot umount -l /proc
     sudo chroot chroot umount -l /sys
     sudo chroot chroot umount -l /dev/pts
+    sudo chroot chroot umount -l /proc
     sudo umount -l chroot/dev
     sudo umount -l chroot/run
 }
+export -f chroot_exit_teardown
 
 function check_host() {
     local os_ver


### PR DESCRIPTION
Description:	Ubuntu 24.04.4 LTS
Release:	24.04
Codename:	noble

I'm running live-custom-ubuntu-from-scratch on a desktop host build for testing.  I'm in the process of building iso's for automation. I found a minor issue while testing build.sh,  chroot_exit_teardown.  It looks like proc is needed for the mount command to unmount /sys and /dev/pts. The build script fails to clean up the chroot.   I have added export -f to allow the functions to be reused in other scripts. 

\# test
\# ./scripts/chroot is in place 
\# nested bash needed to keep active shell from closing  on error 
bash
bash
\# source the 3 chroot functions (paste in a shell) 
chroot_enter_setup
chroot_enter_debug
chroot_exit_teardown

The 3 functions can be executed repeatedly without error, and the chroot_enter_debug will have access to networking each time.